### PR TITLE
Add vertical layout and pagination

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -33,7 +33,35 @@ impl App {
         self.commits.get(self.selected)
     }
 
-    pub fn commits(&self) -> &[CommitRow] {
-        &self.commits
+    /// Returns the zero-based index of the current page.
+    pub fn current_page(&self) -> usize {
+        if self.commits.is_empty() {
+            0
+        } else {
+            self.selected / Self::per_page()
+        }
+    }
+
+    /// Returns the total number of pages.
+    pub fn page_count(&self) -> usize {
+        let per_page = Self::per_page();
+        if self.commits.is_empty() {
+            1
+        } else {
+            (self.commits.len() + per_page - 1) / per_page
+        }
+    }
+
+    /// Items shown on the current page.
+    pub fn page_commits(&self) -> &[CommitRow] {
+        let per_page = Self::per_page();
+        let start = self.current_page() * per_page;
+        let end = usize::min(start + per_page, self.commits.len());
+        &self.commits[start..end]
+    }
+
+    /// Number of commits to display per page.
+    pub const fn per_page() -> usize {
+        10
     }
 }


### PR DESCRIPTION
## Summary
- show selected commit message on top 70% of screen
- render commits table below with pagination info in the top border
- expose page helpers in `App`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6862b62a68d48324a91f0e0df9d6f173