### PR TITLE
Fix layout and pagination controls

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -62,6 +62,6 @@ impl App {
 
     /// Number of commits to display per page.
     pub const fn per_page() -> usize {
-        10
+        25
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -6,9 +6,9 @@ use crossterm::{
 };
 use ratatui::{
     backend::CrosstermBackend,
-    layout::{Constraint, Direction, Layout},
+    layout::{Alignment, Constraint, Direction, Layout},
     style::{Modifier, Style},
-    text::Line,
+    text::{Line, Span},
     widgets::{Block, Borders, Cell, Paragraph, Row, Table, Wrap},
     Terminal,
 };
@@ -84,12 +84,16 @@ impl Tui {
                     Block::default()
                         .borders(Borders::ALL)
                         .title("Message")
-                        .title_bottom(Line::raw(page_info)),
+                        .title_alignment(Alignment::Center)
+                        .title_bottom(Line::from(Span::styled(
+                            page_info,
+                            Style::default().add_modifier(Modifier::BOLD),
+                        ))),
                 )
                 .wrap(Wrap { trim: false });
-            f.render_widget(paragraph, chunks[0]);
+            f.render_widget(table, chunks[0]);
 
-            f.render_widget(table, chunks[1]);
+            f.render_widget(paragraph, chunks[1]);
         })?;
         Ok(())
     }


### PR DESCRIPTION
## Summary
- show commit table in the top 70% of the screen
- move message pane to the bottom 30%
- set default commit page size to 25
- center and bold pagination controls

## Testing
- `rustfmt -v src/app.rs src/tui.rs`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6862b890cf948324a8c76401deb58fc9