### PR TITLE
feat(tui): add time column and pagination info

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -62,6 +62,11 @@ impl App {
 
     /// Number of commits to display per page.
     pub const fn per_page() -> usize {
-        25
+        30
+    }
+
+    /// Total number of commits loaded.
+    pub fn commit_count(&self) -> usize {
+        self.commits.len()
     }
 }

--- a/src/gitlog.rs
+++ b/src/gitlog.rs
@@ -45,7 +45,7 @@ pub fn load_commits(
             url,
             month_year,
             date: datetime,
-            author: commit.author().to_string(),
+            author: commit.author().name().unwrap_or("").to_string(),
             message: commit.message().unwrap_or("").to_string(),
         });
     }


### PR DESCRIPTION
## Summary
- show only author name for git log rows
- add commit time column to commit table
- display pagination and total commits under the table
- increase page size to 30 and enlarge table area

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6864243806608324a4473f084212aeb6