### PR TITLE
feat(tui): handle esc and ctrl-c to quit

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ cargo run -- "this month"
 cargo run -- "jan 1 to feb 15" --repo /path/to/repo
 ```
 
-Use the arrow keys to move through the list. Press `q` to quit.
+Use the arrow keys to move through the list. Press `q`, `Esc`, or `Ctrl-C` to quit.
 
 ## Features
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -48,7 +48,7 @@ impl App {
         if self.commits.is_empty() {
             1
         } else {
-            (self.commits.len() + per_page - 1) / per_page
+            self.commits.len().div_ceil(per_page)
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,12 +8,12 @@ use anyhow::Result;
 use chrono::{DateTime, Duration, Utc};
 use chrono_english::{parse_date_string, parse_duration, Dialect, Interval};
 use clap::Parser;
-use crossterm::event::{self, Event, KeyCode};
+use crossterm::event::{self, Event, KeyCode, KeyModifiers};
 use std::time::Duration as StdDuration;
 
 /// Parses a natural language time range into a (since, until) tuple.
 /// Parses a natural language time range using `chrono-english`.
-fn parse_range(input: &str) -> Result<(DateTime<Utc>, DateTime<Utc>)> {
+pub(crate) fn parse_range(input: &str) -> Result<(DateTime<Utc>, DateTime<Utc>)> {
     let now = Utc::now();
     let input = input.trim();
     let lower = input.to_lowercase();
@@ -63,10 +63,11 @@ fn main() -> Result<()> {
 
         if event::poll(StdDuration::from_millis(200))? {
             if let Event::Key(key) = event::read()? {
-                match key.code {
-                    KeyCode::Char('q') => break,
-                    KeyCode::Down => app.next(),
-                    KeyCode::Up => app.previous(),
+                match (key.code, key.modifiers) {
+                    (KeyCode::Char('q'), _) | (KeyCode::Esc, _) => break,
+                    (KeyCode::Char('c'), KeyModifiers::CONTROL) => break,
+                    (KeyCode::Down, _) => app.next(),
+                    (KeyCode::Up, _) => app.previous(),
                     _ => {}
                 }
             }
@@ -75,4 +76,21 @@ fn main() -> Result<()> {
 
     terminal.shutdown()?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_range_defaults_to_last_year() {
+        let (since, until) = parse_range("nonsense").unwrap();
+        assert!(until > since);
+    }
+
+    #[test]
+    fn parse_range_since_keyword() {
+        let (since, until) = parse_range("since yesterday").unwrap();
+        assert!(until > since);
+    }
 }


### PR DESCRIPTION
## Summary
- exit the app if Esc or Ctrl-C is pressed
- document the new quit keys
- test `parse_range`
- clean up a clippy lint in `App::page_count`

## Testing
- `cargo fmt -v`
- `cargo clippy`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68642525203883249a0e7563f5c838df