### PR TITLE
test(app): expand coverage for navigation and range parsing

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -70,3 +70,63 @@ impl App {
         self.commits.len()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::DateTime;
+
+    fn make_commit(id: usize) -> CommitRow {
+        let date = DateTime::parse_from_rfc3339("2020-01-01T00:00:00Z").unwrap();
+        CommitRow {
+            sha: format!("{:07x}", id),
+            url: None,
+            month_year: "January 2020".into(),
+            date,
+            author: "Test".into(),
+            message: format!("commit {}", id),
+        }
+    }
+
+    fn sample_app(count: usize) -> App {
+        let commits = (0..count).map(make_commit).collect();
+        App::new(commits)
+    }
+
+    #[test]
+    fn next_wraps_to_start() {
+        let mut app = sample_app(2);
+        app.next();
+        app.next();
+        assert_eq!(app.selected, 0);
+    }
+
+    #[test]
+    fn previous_wraps_to_end() {
+        let mut app = sample_app(3);
+        app.previous();
+        assert_eq!(app.selected, 2);
+    }
+
+    #[test]
+    fn page_count_computes_ceil() {
+        let app = sample_app(App::per_page() * 2 + 1);
+        assert_eq!(app.page_count(), 3);
+    }
+
+    #[test]
+    fn page_commits_returns_correct_slice() {
+        let mut app = sample_app(App::per_page() + 5);
+        assert_eq!(app.page_commits().len(), App::per_page());
+        app.selected = App::per_page();
+        assert_eq!(app.page_commits().len(), 5);
+    }
+
+    #[test]
+    fn current_page_reflects_selection() {
+        let mut app = sample_app(App::per_page() + 1);
+        assert_eq!(app.current_page(), 0);
+        app.selected = App::per_page();
+        assert_eq!(app.current_page(), 1);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,6 +81,7 @@ fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Datelike;
 
     #[test]
     fn parse_range_defaults_to_last_year() {
@@ -92,5 +93,13 @@ mod tests {
     fn parse_range_since_keyword() {
         let (since, until) = parse_range("since yesterday").unwrap();
         assert!(until > since);
+    }
+
+    #[test]
+    fn parse_range_with_explicit_range() {
+        let (since, until) = parse_range("2020-01-01 to 2020-01-10").unwrap();
+        assert!(until > since);
+        assert_eq!(since.year(), 2020);
+        assert_eq!(until.year(), 2020);
     }
 }


### PR DESCRIPTION
## Summary
- add unit tests for `App` navigation and paging logic
- add test for explicit date ranges

## Testing
- `cargo fmt -v`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6864318649588324888a6053904a294a